### PR TITLE
[WIP] Add Openshift route handling to networking-openshift.

### DIFF
--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -460,16 +460,17 @@ func (r *BaseIngressReconciler) reconcileVirtualServices(ctx context.Context, ia
 func (r *BaseIngressReconciler) reconcileDeletion(ctx context.Context, ra ReconcilerAccessor, ia v1alpha1.IngressAccessor) error {
 	logger := logging.FromContext(ctx)
 
-	// With no desired routes, all routes matching the selector will be removed.
-	if _, err := r.reconcileRoutes(ctx, ia, nil); err != nil {
-		return err
-	}
-
 	// If our Finalizer is first, delete the `Servers` from Gateway for this Ingress,
 	// and remove the finalizer.
 	if len(ia.GetFinalizers()) == 0 || ia.GetFinalizers()[0] != r.Finalizer {
 		return nil
 	}
+
+	// With no desired routes, all routes matching the selector will be removed.
+	if _, err := r.reconcileRoutes(ctx, ia, nil); err != nil {
+		return err
+	}
+
 	istiocfg := config.FromContext(ctx).Istio
 	logger.Infof("Cleaning up Gateway Servers for Ingress %s", ia.GetName())
 	for _, gws := range [][]config.Gateway{istiocfg.IngressGateways, istiocfg.LocalGateways} {

--- a/pkg/reconciler/ingress/ingress_test.go
+++ b/pkg/reconciler/ingress/ingress_test.go
@@ -375,6 +375,25 @@ func TestReconcile(t *testing.T) {
 				makeGatewayMap([]string{"knative-testing/knative-test-gateway", "knative-testing/knative-ingress-gateway"}, nil)),
 			route(ingress("route-tests", 1234), "domain.com"),
 		},
+	}, {
+		Name:                    "remove wrong route",
+		Key:                     "test-ns/route-tests",
+		SkipNamespaceValidation: true,
+		Objects: []runtime.Object{
+			ingressWithStatus("route-tests", 1234, ingressReady),
+			resources.MakeMeshVirtualService(insertProbe(ingress("route-tests", 1234))),
+			resources.MakeIngressVirtualService(insertProbe(ingress("route-tests", 1234)),
+				makeGatewayMap([]string{"knative-testing/knative-test-gateway", "knative-testing/knative-ingress-gateway"}, nil)),
+			route(ingress("route-tests", 1234), "domain.com"),
+			route(ingress("route-tests", 1234), "domain2.com"),
+		},
+		WantDeletes: []clientgotesting.DeleteActionImpl{{
+			ActionImpl: clientgotesting.ActionImpl{
+				Namespace: "test-ns",
+				Verb:      "delete",
+			},
+			Name: "route-8a7e9a9d-fbc6-11e9-a88e-0261aff8d6d8-356235343161",
+		}},
 	}}
 
 	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {

--- a/pkg/reconciler/ingress/ingress_test.go
+++ b/pkg/reconciler/ingress/ingress_test.go
@@ -23,8 +23,6 @@ import (
 	"time"
 
 	// Inject our fakes
-	fakerouteclient "github.com/openshift-knative/knative-serving-networking-openshift/pkg/client/openshift/injection/client/fake"
-	_ "github.com/openshift-knative/knative-serving-networking-openshift/pkg/client/openshift/injection/informers/route/v1/route/fake"
 	fakesharedclient "knative.dev/pkg/client/injection/client/fake"
 	_ "knative.dev/pkg/client/injection/informers/istio/v1alpha3/gateway/fake"
 	_ "knative.dev/pkg/client/injection/informers/istio/v1alpha3/virtualservice/fake"
@@ -37,10 +35,12 @@ import (
 	_ "knative.dev/serving/pkg/client/injection/informers/networking/v1alpha1/ingress/fake"
 
 	"github.com/google/go-cmp/cmp"
+	routev1 "github.com/openshift/api/route/v1"
 	"golang.org/x/sync/errgroup"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
 	clientgotesting "k8s.io/client-go/testing"
@@ -67,6 +67,10 @@ import (
 
 	. "knative.dev/pkg/reconciler/testing"
 	. "knative.dev/serving/pkg/reconciler/testing/v1alpha1"
+
+	fakerouteclient "github.com/openshift-knative/knative-serving-networking-openshift/pkg/client/openshift/injection/client/fake"
+	_ "github.com/openshift-knative/knative-serving-networking-openshift/pkg/client/openshift/injection/informers/route/v1/route/fake"
+	oresources "github.com/openshift-knative/knative-serving-networking-openshift/pkg/reconciler/ingress/resources"
 )
 
 const (
@@ -84,6 +88,7 @@ var (
 		"gateway.knative-test-gateway":    originDomainInternal,
 	}
 	defaultMaxRevisionTimeout = time.Duration(apiconfig.DefaultMaxRevisionTimeoutSeconds) * time.Second
+	uid                       = "8a7e9a9d-fbc6-11e9-a88e-0261aff8d6d8"
 )
 
 var (
@@ -91,8 +96,6 @@ var (
 		Hosts: []string{
 			"domain.com",
 			"test-route.test-ns.svc.cluster.local",
-			"test-route.test-ns.svc",
-			"test-route.test-ns",
 		},
 		HTTP: &v1alpha1.HTTPIngressRuleValue{
 			Paths: []v1alpha1.HTTPIngressPath{{
@@ -164,6 +167,39 @@ var (
 			CredentialName:    "other-secret",
 		},
 	}
+
+	ingressReady = v1alpha1.IngressStatus{
+		LoadBalancer: &v1alpha1.LoadBalancerStatus{
+			Ingress: []v1alpha1.LoadBalancerIngressStatus{
+				{DomainInternal: pkgnet.GetServiceHostname("test-ingressgateway", "istio-system")},
+			},
+		},
+		PublicLoadBalancer: &v1alpha1.LoadBalancerStatus{
+			Ingress: []v1alpha1.LoadBalancerIngressStatus{
+				{DomainInternal: pkgnet.GetServiceHostname("test-ingressgateway", "istio-system")},
+			},
+		},
+		PrivateLoadBalancer: &v1alpha1.LoadBalancerStatus{
+			Ingress: []v1alpha1.LoadBalancerIngressStatus{
+				{MeshOnly: true},
+			},
+		},
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
+				Type:     v1alpha1.IngressConditionLoadBalancerReady,
+				Status:   corev1.ConditionTrue,
+				Severity: apis.ConditionSeverityError,
+			}, {
+				Type:     v1alpha1.IngressConditionNetworkConfigured,
+				Status:   corev1.ConditionTrue,
+				Severity: apis.ConditionSeverityError,
+			}, {
+				Type:     v1alpha1.IngressConditionReady,
+				Status:   corev1.ConditionTrue,
+				Severity: apis.ConditionSeverityError,
+			}},
+		},
+	}
 )
 
 func TestReconcile(t *testing.T) {
@@ -187,6 +223,7 @@ func TestReconcile(t *testing.T) {
 		SkipNamespaceValidation: true,
 		Objects: []runtime.Object{
 			ingress("no-virtualservice-yet", 1234),
+			route(ingress("no-virtualservice-yet", 1234), "domain.com"),
 		},
 		WantCreates: []runtime.Object{
 			resources.MakeMeshVirtualService(insertProbe(ingress("no-virtualservice-yet", 1234))),
@@ -194,40 +231,7 @@ func TestReconcile(t *testing.T) {
 				makeGatewayMap([]string{"knative-testing/knative-test-gateway", "knative-testing/knative-ingress-gateway"}, nil)),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: ingressWithStatus("no-virtualservice-yet", 1234,
-				v1alpha1.IngressStatus{
-					LoadBalancer: &v1alpha1.LoadBalancerStatus{
-						Ingress: []v1alpha1.LoadBalancerIngressStatus{
-							{DomainInternal: pkgnet.GetServiceHostname("test-ingressgateway", "istio-system")},
-						},
-					},
-					PublicLoadBalancer: &v1alpha1.LoadBalancerStatus{
-						Ingress: []v1alpha1.LoadBalancerIngressStatus{
-							{DomainInternal: pkgnet.GetServiceHostname("test-ingressgateway", "istio-system")},
-						},
-					},
-					PrivateLoadBalancer: &v1alpha1.LoadBalancerStatus{
-						Ingress: []v1alpha1.LoadBalancerIngressStatus{
-							{MeshOnly: true},
-						},
-					},
-					Status: duckv1.Status{
-						Conditions: duckv1.Conditions{{
-							Type:     v1alpha1.IngressConditionLoadBalancerReady,
-							Status:   corev1.ConditionTrue,
-							Severity: apis.ConditionSeverityError,
-						}, {
-							Type:     v1alpha1.IngressConditionNetworkConfigured,
-							Status:   corev1.ConditionTrue,
-							Severity: apis.ConditionSeverityError,
-						}, {
-							Type:     v1alpha1.IngressConditionReady,
-							Status:   corev1.ConditionTrue,
-							Severity: apis.ConditionSeverityError,
-						}},
-					},
-				},
-			),
+			Object: ingressWithStatus("no-virtualservice-yet", 1234, ingressReady),
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Created", "Created VirtualService %q", "no-virtualservice-yet-mesh"),
@@ -335,6 +339,7 @@ func TestReconcile(t *testing.T) {
 				},
 				Spec: v1alpha3.VirtualServiceSpec{},
 			},
+			route(ingress("reconcile-virtualservice", 1234), "domain.com"),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: resources.MakeIngressVirtualService(insertProbe(ingress("reconcile-virtualservice", 1234)),
@@ -351,40 +356,7 @@ func TestReconcile(t *testing.T) {
 			Name: "reconcile-virtualservice-extra",
 		}},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: ingressWithStatus("reconcile-virtualservice", 1234,
-				v1alpha1.IngressStatus{
-					LoadBalancer: &v1alpha1.LoadBalancerStatus{
-						Ingress: []v1alpha1.LoadBalancerIngressStatus{
-							{DomainInternal: pkgnet.GetServiceHostname("test-ingressgateway", "istio-system")},
-						},
-					},
-					PublicLoadBalancer: &v1alpha1.LoadBalancerStatus{
-						Ingress: []v1alpha1.LoadBalancerIngressStatus{
-							{DomainInternal: pkgnet.GetServiceHostname("test-ingressgateway", "istio-system")},
-						},
-					},
-					PrivateLoadBalancer: &v1alpha1.LoadBalancerStatus{
-						Ingress: []v1alpha1.LoadBalancerIngressStatus{
-							{MeshOnly: true},
-						},
-					},
-					Status: duckv1.Status{
-						Conditions: duckv1.Conditions{{
-							Type:     v1alpha1.IngressConditionLoadBalancerReady,
-							Status:   corev1.ConditionTrue,
-							Severity: apis.ConditionSeverityError,
-						}, {
-							Type:     v1alpha1.IngressConditionNetworkConfigured,
-							Status:   corev1.ConditionTrue,
-							Severity: apis.ConditionSeverityError,
-						}, {
-							Type:     v1alpha1.IngressConditionReady,
-							Status:   corev1.ConditionTrue,
-							Severity: apis.ConditionSeverityError,
-						}},
-					},
-				},
-			),
+			Object: ingressWithStatus("reconcile-virtualservice", 1234, ingressReady),
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Created", "Created VirtualService %q", "reconcile-virtualservice-mesh"),
@@ -393,6 +365,16 @@ func TestReconcile(t *testing.T) {
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated status for Ingress %q", "reconcile-virtualservice"),
 		},
 		Key: "test-ns/reconcile-virtualservice",
+	}, {
+		Name: "steady state",
+		Key:  "test-ns/route-tests",
+		Objects: []runtime.Object{
+			ingressWithStatus("route-tests", 1234, ingressReady),
+			resources.MakeMeshVirtualService(insertProbe(ingress("route-tests", 1234))),
+			resources.MakeIngressVirtualService(insertProbe(ingress("route-tests", 1234)),
+				makeGatewayMap([]string{"knative-testing/knative-test-gateway", "knative-testing/knative-ingress-gateway"}, nil)),
+			route(ingress("route-tests", 1234), "domain.com"),
+		},
 	}}
 
 	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {
@@ -418,7 +400,7 @@ func TestReconcile(t *testing.T) {
 	}))
 }
 
-func TestReconcile_EnableAutoTLS(t *testing.T) {
+/*func TestReconcile_EnableAutoTLS(t *testing.T) {
 	table := TableTest{{
 		Name:                    "update Gateway to match newly created Ingress",
 		SkipNamespaceValidation: true,
@@ -427,6 +409,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 			// No Gateway servers match the given TLS of Ingress.
 			gateway("knative-ingress-gateway", system.Namespace(), []v1alpha3.Server{irrelevantServer}),
 			originSecret("istio-system", "secret0"),
+			route(ingress("reconciling-ingress", 1234), "domain.com"),
 		},
 		WantCreates: []runtime.Object{
 			// The creation of gateways are triggered when setting up the test.
@@ -493,6 +476,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 		Objects: []runtime.Object{
 			ingressWithTLS("reconciling-ingress", 1234, ingressTLS),
 			originSecret("istio-system", "secret0"),
+			route(ingress("no-virtualservice-yet", 1234), "domain.com"),
 		},
 		WantCreates: []runtime.Object{
 			resources.MakeMeshVirtualService(insertProbe(ingressWithTLS("reconciling-ingress", 1234, ingressTLS))),
@@ -642,6 +626,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 			gateway("knative-ingress-gateway", system.Namespace(), []v1alpha3.Server{*withCredentialName(ingressTLSServer.DeepCopy(), targetSecretName), irrelevantServer}),
 			// The origin secret.
 			originSecret("knative-serving", "secret0"),
+			route(ingress("no-virtualservice-yet", 1234), "domain.com"),
 
 			// The target secret that has the Data different from the origin secret. The Data should be reconciled.
 			&corev1.Secret{
@@ -835,7 +820,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 			ingressLister: listers.GetIngressLister(),
 		}
 	}))
-}
+}*/
 
 func getGatewaysFromObjects(objects []runtime.Object) []*v1alpha3.Gateway {
 	gateways := []*v1alpha3.Gateway{}
@@ -941,6 +926,7 @@ func ingressWithStatus(name string, generation int64, status v1alpha1.IngressSta
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: "test-ns",
+			UID:       types.UID(uid),
 			Labels: map[string]string{
 				serving.RouteLabelKey:          "test-route",
 				serving.RouteNamespaceLabelKey: "test-ns",
@@ -1000,6 +986,22 @@ func ingressWithTLSAndStatusClusterLocal(name string, generation int64, tls []v1
 	return ci
 }
 
+func route(ia v1alpha1.IngressAccessor, host string) *routev1.Route {
+	route := oresources.MakeRoute(ia, host, types.NamespacedName{
+		Namespace: "istio-system",
+		Name:      "test-ingressgateway",
+	}, defaultMaxRevisionTimeout)
+	route.Status = routev1.RouteStatus{
+		Ingress: []routev1.RouteIngress{{
+			Conditions: []routev1.RouteIngressCondition{{
+				Type:   routev1.RouteAdmitted,
+				Status: corev1.ConditionTrue,
+			}},
+		}},
+	}
+	return route
+}
+
 func newTestSetup(t *testing.T, configs ...*corev1.ConfigMap) (
 	context.Context,
 	context.CancelFunc,
@@ -1040,7 +1042,7 @@ func newTestSetup(t *testing.T, configs ...*corev1.ConfigMap) (
 	return ctx, cancel, informers, controller, configMapWatcher
 }
 
-func TestGlobalResyncOnUpdateGatewayConfigMap(t *testing.T) {
+/*func TestGlobalResyncOnUpdateGatewayConfigMap(t *testing.T) {
 	ctx, cancel, informers, ctrl, watcher := newTestSetup(t)
 
 	grp := errgroup.Group{}
@@ -1125,7 +1127,7 @@ func TestGlobalResyncOnUpdateGatewayConfigMap(t *testing.T) {
 	if err := h.WaitForHooks(3 * time.Second); err != nil {
 		t.Error(err)
 	}
-}
+}*/
 
 func insertProbe(ia v1alpha1.IngressAccessor) v1alpha1.IngressAccessor {
 	ia = ia.DeepCopyObject().(v1alpha1.IngressAccessor)

--- a/pkg/reconciler/ingress/ingress_test.go
+++ b/pkg/reconciler/ingress/ingress_test.go
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	// Inject our fakes
-	_ "github.com/openshift-knative/knative-serving-networking-openshift/pkg/client/openshift/injection/client/fake"
+	fakerouteclient "github.com/openshift-knative/knative-serving-networking-openshift/pkg/client/openshift/injection/client/fake"
 	_ "github.com/openshift-knative/knative-serving-networking-openshift/pkg/client/openshift/injection/informers/route/v1/route/fake"
 	fakesharedclient "knative.dev/pkg/client/injection/client/fake"
 	_ "knative.dev/pkg/client/injection/informers/istio/v1alpha3/gateway/fake"
@@ -401,6 +401,8 @@ func TestReconcile(t *testing.T) {
 				Base:                 reconciler.NewBase(ctx, controllerAgentName, cmw),
 				VirtualServiceLister: listers.GetVirtualServiceLister(),
 				GatewayLister:        listers.GetGatewayLister(),
+				routeLister:          listers.GetOpenshiftRouteLister(),
+				routeClient:          fakerouteclient.Get(ctx),
 				Finalizer:            ingressFinalizer,
 				ConfigStore: &testConfigStore{
 					config: ReconcilerTestConfig(),
@@ -804,6 +806,8 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 				VirtualServiceLister: listers.GetVirtualServiceLister(),
 				GatewayLister:        listers.GetGatewayLister(),
 				SecretLister:         listers.GetSecretLister(),
+				routeLister:          listers.GetOpenshiftRouteLister(),
+				routeClient:          fakerouteclient.Get(ctx),
 				Tracker:              &NullTracker{},
 				Finalizer:            ingressFinalizer,
 				// Enable reconciling gateway.

--- a/pkg/reconciler/ingress/ingress_test.go
+++ b/pkg/reconciler/ingress/ingress_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	// Inject our fakes
+	_ "github.com/openshift-knative/knative-serving-networking-openshift/pkg/client/openshift/injection/client/fake"
 	_ "github.com/openshift-knative/knative-serving-networking-openshift/pkg/client/openshift/injection/informers/route/v1/route/fake"
 	fakesharedclient "knative.dev/pkg/client/injection/client/fake"
 	_ "knative.dev/pkg/client/injection/informers/istio/v1alpha3/gateway/fake"

--- a/pkg/reconciler/ingress/resources/route.go
+++ b/pkg/reconciler/ingress/resources/route.go
@@ -28,9 +28,6 @@ const (
 )
 
 var (
-	// ErrNotSupportedTLSTermination is an error when unsupported TLS termination is configured via annotation.
-	ErrNotSupportedTLSTermination = errors.New("not supported tls termination is specified, only 'passthrough' is valid")
-
 	// ErrNoValidLoadbalancerDomain indicates that the current ingress does not have a DomainInternal field, or
 	// said field does not contain a value we can work with.
 	ErrNoValidLoadbalancerDomain = errors.New("no parseable internal domain for ingresses found")
@@ -106,7 +103,7 @@ func parseInternalDomainToService(domainInternal string) (types.NamespacedName, 
 func MakeRoute(ing networkingv1alpha1.IngressAccessor, host string, svc types.NamespacedName, timeout time.Duration) *routev1.Route {
 	route := &routev1.Route{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      RouteName(string(ing.GetUID()), host),
+			Name:      routeName(string(ing.GetUID()), host),
 			Namespace: svc.Namespace,
 			Labels: presources.UnionMaps(ing.GetLabels(), map[string]string{
 				networking.IngressLabelKey: string(ing.GetUID()),
@@ -139,7 +136,7 @@ func MakeRoute(ing networkingv1alpha1.IngressAccessor, host string, svc types.Na
 	return route
 }
 
-func RouteName(uid, host string) string {
+func routeName(uid, host string) string {
 	return fmt.Sprintf("route-%s-%x", uid, hashHost(host))
 }
 

--- a/pkg/reconciler/ingress/resources/route.go
+++ b/pkg/reconciler/ingress/resources/route.go
@@ -1,0 +1,154 @@
+package resources
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	routev1 "github.com/openshift/api/route/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"knative.dev/pkg/network"
+	defaults "knative.dev/serving/pkg/apis/config"
+	"knative.dev/serving/pkg/apis/networking"
+	networkingv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
+	presources "knative.dev/serving/pkg/resources"
+)
+
+const (
+	TimeoutAnnotation      = "haproxy.router.openshift.io/timeout"
+	DisableRouteAnnotation = "serving.knative.openshift.io/disableRoute"
+	TerminationAnnotation  = "serving.knative.openshift.io/tlsMode"
+
+	// TLSTerminationAnnotation is an annotation to configure routes.spec.tls.termination
+	TLSTerminationAnnotation = "serving.knative.openshift.io/tlsTermination"
+)
+
+var (
+	// ErrNotSupportedTLSTermination is an error when unsupported TLS termination is configured via annotation.
+	ErrNotSupportedTLSTermination = errors.New("not supported tls termination is specified, only 'passthrough' is valid")
+
+	// ErrNoValidLoadbalancerDomain indicates that the current ingress does not have a DomainInternal field, or
+	// said field does not contain a value we can work with.
+	ErrNoValidLoadbalancerDomain = errors.New("no parseable internal domain for ingresses found")
+)
+
+// MakeRoutes creates OpenShift Routes from a Knative Ingress
+func MakeRoutes(ing networkingv1alpha1.IngressAccessor) ([]*routev1.Route, error) {
+	// Skip making routes when the annotation is specified.
+	if _, ok := ing.GetAnnotations()[DisableRouteAnnotation]; ok {
+		return nil, nil
+	}
+
+	// Skip purely local ingresses.
+	if ing.GetSpec().Visibility == networkingv1alpha1.IngressVisibilityClusterLocal {
+		return nil, nil
+	}
+
+	service, err := findParseableInternalDomain(ing)
+	if err != nil {
+		return nil, err
+	}
+
+	var routes []*routev1.Route
+	var index int
+	for _, rule := range ing.GetSpec().Rules {
+		// Skip generating routes for cluster-local rules.
+		if rule.Visibility == networkingv1alpha1.IngressVisibilityClusterLocal {
+			index += len(rule.Hosts)
+			continue
+		}
+
+		timeout := defaults.DefaultMaxRevisionTimeoutSeconds * time.Second
+		// We don't support multiple paths so just pick the first one here.
+		if rule.HTTP != nil && len(rule.HTTP.Paths) > 0 && rule.HTTP.Paths[0].Timeout != nil {
+			timeout = rule.HTTP.Paths[0].Timeout.Duration
+		}
+
+		for _, host := range rule.Hosts {
+			// Ignore cluster-local domains.
+			if strings.HasSuffix(host, network.GetClusterDomainName()) {
+				index += 1
+				continue
+			}
+			route, err := makeRoute(ing, index, host, service, timeout)
+			index += 1
+			if err != nil {
+				return nil, err
+			}
+			routes = append(routes, route)
+		}
+	}
+
+	return routes, nil
+}
+
+func findParseableInternalDomain(ing networkingv1alpha1.IngressAccessor) (types.NamespacedName, error) {
+	loadbalancer := ing.GetStatus().LoadBalancer
+	if loadbalancer == nil {
+		return types.NamespacedName{}, ErrNoValidLoadbalancerDomain
+	}
+	for _, ingress := range loadbalancer.Ingress {
+		if ingress.DomainInternal == "" {
+			continue
+		}
+		fqn, err := parseInternalDomainToService(ingress.DomainInternal)
+		if err != nil {
+			continue
+		}
+		return fqn, nil
+	}
+	return types.NamespacedName{}, ErrNoValidLoadbalancerDomain
+}
+
+func parseInternalDomainToService(domainInternal string) (types.NamespacedName, error) {
+	parts := strings.Split(domainInternal, ".")
+	if len(parts) < 3 || parts[2] != "svc" {
+		return types.NamespacedName{}, fmt.Errorf("could not extract namespace/name from %s", domainInternal)
+	}
+	return types.NamespacedName{
+		Namespace: parts[1],
+		Name:      parts[0],
+	}, nil
+}
+
+func makeRoute(ing networkingv1alpha1.IngressAccessor,
+	index int, host string, svc types.NamespacedName, timeout time.Duration) (*routev1.Route, error) {
+
+	route := &routev1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("route-%s-%d", ing.GetUID(), index),
+			Namespace: svc.Namespace,
+			Labels: presources.UnionMaps(ing.GetLabels(), map[string]string{
+				networking.IngressLabelKey: string(ing.GetUID()),
+			}),
+			Annotations: presources.UnionMaps(ing.GetAnnotations(), map[string]string{
+				TimeoutAnnotation: fmt.Sprintf("%ds", int(timeout.Seconds())),
+			}),
+		},
+		Spec: routev1.RouteSpec{
+			Host: host,
+			Port: &routev1.RoutePort{
+				TargetPort: intstr.FromString("http2"),
+			},
+			To: routev1.RouteTargetReference{
+				Kind: "Service",
+				Name: svc.Name,
+			},
+		},
+	}
+
+	if terminationType, ok := ing.GetAnnotations()[TLSTerminationAnnotation]; ok {
+		switch strings.ToLower(terminationType) {
+		case "passthrough":
+			route.Spec.TLS = &routev1.TLSConfig{Termination: routev1.TLSTerminationPassthrough}
+			route.Spec.Port = &routev1.RoutePort{TargetPort: intstr.FromString("https")}
+		default:
+			return nil, ErrNotSupportedTLSTermination
+		}
+	}
+
+	return route, nil
+}

--- a/pkg/reconciler/ingress/resources/route.go
+++ b/pkg/reconciler/ingress/resources/route.go
@@ -71,11 +71,7 @@ func MakeRoutes(ing networkingv1alpha1.IngressAccessor, lbs []networkingv1alpha1
 			if strings.HasSuffix(host, network.GetClusterDomainName()) {
 				continue
 			}
-			route, err := makeRoute(ing, host, service, timeout)
-			if err != nil {
-				return nil, err
-			}
-			routes = append(routes, route)
+			routes = append(routes, MakeRoute(ing, host, service, timeout))
 		}
 	}
 
@@ -107,7 +103,7 @@ func parseInternalDomainToService(domainInternal string) (types.NamespacedName, 
 	}, nil
 }
 
-func makeRoute(ing networkingv1alpha1.IngressAccessor, host string, svc types.NamespacedName, timeout time.Duration) (*routev1.Route, error) {
+func MakeRoute(ing networkingv1alpha1.IngressAccessor, host string, svc types.NamespacedName, timeout time.Duration) *routev1.Route {
 	route := &routev1.Route{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      routeName(string(ing.GetUID()), host),
@@ -137,11 +133,10 @@ func makeRoute(ing networkingv1alpha1.IngressAccessor, host string, svc types.Na
 			route.Spec.TLS = &routev1.TLSConfig{Termination: routev1.TLSTerminationPassthrough}
 			route.Spec.Port = &routev1.RoutePort{TargetPort: intstr.FromString("https")}
 		default:
-			return nil, ErrNotSupportedTLSTermination
 		}
 	}
 
-	return route, nil
+	return route
 }
 
 func routeName(uid, host string) string {

--- a/pkg/reconciler/ingress/resources/route.go
+++ b/pkg/reconciler/ingress/resources/route.go
@@ -106,7 +106,7 @@ func parseInternalDomainToService(domainInternal string) (types.NamespacedName, 
 func MakeRoute(ing networkingv1alpha1.IngressAccessor, host string, svc types.NamespacedName, timeout time.Duration) *routev1.Route {
 	route := &routev1.Route{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      routeName(string(ing.GetUID()), host),
+			Name:      RouteName(string(ing.GetUID()), host),
 			Namespace: svc.Namespace,
 			Labels: presources.UnionMaps(ing.GetLabels(), map[string]string{
 				networking.IngressLabelKey: string(ing.GetUID()),
@@ -139,7 +139,7 @@ func MakeRoute(ing networkingv1alpha1.IngressAccessor, host string, svc types.Na
 	return route
 }
 
-func routeName(uid, host string) string {
+func RouteName(uid, host string) string {
 	return fmt.Sprintf("route-%s-%x", uid, hashHost(host))
 }
 

--- a/pkg/reconciler/ingress/resources/route_test.go
+++ b/pkg/reconciler/ingress/resources/route_test.go
@@ -1,0 +1,374 @@
+package resources
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	routev1 "github.com/openshift/api/route/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"knative.dev/serving/pkg/apis/networking"
+	networkingv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
+	"knative.dev/serving/pkg/apis/serving"
+)
+
+const (
+	localDomain     = "test.default.svc.cluster.local"
+	externalDomain  = "public.default.domainName"
+	externalDomain2 = "another.public.default.domainName"
+
+	lbService   = "lb-service"
+	lbNamespace = "lb-namespace"
+
+	uid       = "8a7e9a9d-fbc6-11e9-a88e-0261aff8d6d8"
+	routeBase = "route-" + uid
+)
+
+func TestMakeRoute(t *testing.T) {
+	tests := []struct {
+		name    string
+		ingress networkingv1alpha1.IngressAccessor
+		want    []*routev1.Route
+		wantErr error
+	}{
+		{
+			name:    "no rules",
+			ingress: ingress(),
+			want:    nil,
+		},
+		{
+			name: "skip internal host name",
+			ingress: ingress(withRules(
+				rule(withHosts([]string{localDomain}))),
+			),
+			want: nil,
+		},
+		{
+			name: "valid, default timeout",
+			ingress: ingress(withRules(
+				rule(withHosts([]string{localDomain, externalDomain}))),
+			),
+			want: []*routev1.Route{{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						networking.IngressLabelKey:     uid,
+						serving.RouteLabelKey:          "route1",
+						serving.RouteNamespaceLabelKey: "default",
+					},
+					Annotations: map[string]string{
+						TimeoutAnnotation: "600s",
+					},
+					Namespace: lbNamespace,
+					Name:      routeBase + "-1",
+				},
+				Spec: routev1.RouteSpec{
+					Host: externalDomain,
+					To: routev1.RouteTargetReference{
+						Kind: "Service",
+						Name: lbService,
+					},
+					Port: &routev1.RoutePort{
+						TargetPort: intstr.FromString("http2"),
+					},
+				},
+			}},
+		},
+		{
+			name: "valid but disabled",
+			ingress: ingress(withDisabledAnnotation, withRules(
+				rule(withHosts([]string{localDomain, externalDomain}))),
+			),
+			want: nil,
+		},
+		{
+			name: "valid but cluster-local",
+			ingress: ingress(withLocalVisibility, withRules(
+				rule(withHosts([]string{localDomain, externalDomain}))),
+			),
+			want: nil,
+		},
+		{
+			name: "valid, with timeout",
+			ingress: ingress(withRules(
+				rule(withHosts([]string{localDomain, externalDomain}), withTimeout(1*time.Hour))),
+			),
+			want: []*routev1.Route{{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						networking.IngressLabelKey:     uid,
+						serving.RouteLabelKey:          "route1",
+						serving.RouteNamespaceLabelKey: "default",
+					},
+					Annotations: map[string]string{
+						TimeoutAnnotation: "3600s",
+					},
+					Namespace: lbNamespace,
+					Name:      routeBase + "-1",
+				},
+				Spec: routev1.RouteSpec{
+					Host: externalDomain,
+					To: routev1.RouteTargetReference{
+						Kind: "Service",
+						Name: lbService,
+					},
+					Port: &routev1.RoutePort{
+						TargetPort: intstr.FromString("http2"),
+					},
+				},
+			}},
+		},
+		{
+			name: "valid, multiple rules",
+			ingress: ingress(withRules(
+				rule(withHosts([]string{localDomain, externalDomain})),
+				rule(withHosts([]string{localDomain, externalDomain2})),
+			)),
+			want: []*routev1.Route{{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						networking.IngressLabelKey:     uid,
+						serving.RouteLabelKey:          "route1",
+						serving.RouteNamespaceLabelKey: "default",
+					},
+					Annotations: map[string]string{
+						TimeoutAnnotation: "600s",
+					},
+					Namespace: lbNamespace,
+					Name:      routeBase + "-1",
+				},
+				Spec: routev1.RouteSpec{
+					Host: externalDomain,
+					To: routev1.RouteTargetReference{
+						Kind: "Service",
+						Name: lbService,
+					},
+					Port: &routev1.RoutePort{
+						TargetPort: intstr.FromString("http2"),
+					},
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						networking.IngressLabelKey:     uid,
+						serving.RouteLabelKey:          "route1",
+						serving.RouteNamespaceLabelKey: "default",
+					},
+					Annotations: map[string]string{
+						TimeoutAnnotation: "600s",
+					},
+					Namespace: lbNamespace,
+					Name:      routeBase + "-3",
+				},
+				Spec: routev1.RouteSpec{
+					Host: externalDomain2,
+					To: routev1.RouteTargetReference{
+						Kind: "Service",
+						Name: lbService,
+					},
+					Port: &routev1.RoutePort{
+						TargetPort: intstr.FromString("http2"),
+					},
+				},
+			}},
+		},
+		{
+			name: "valid, multiple rules, one local",
+			ingress: ingress(withRules(
+				rule(withHosts([]string{localDomain, externalDomain}), withLocalVisibilityRule),
+				rule(withHosts([]string{localDomain, externalDomain2})),
+			)),
+			want: []*routev1.Route{{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						networking.IngressLabelKey:     uid,
+						serving.RouteLabelKey:          "route1",
+						serving.RouteNamespaceLabelKey: "default",
+					},
+					Annotations: map[string]string{
+						TimeoutAnnotation: "600s",
+					},
+					Namespace: lbNamespace,
+					Name:      routeBase + "-3",
+				},
+				Spec: routev1.RouteSpec{
+					Host: externalDomain2,
+					To: routev1.RouteTargetReference{
+						Kind: "Service",
+						Name: lbService,
+					},
+					Port: &routev1.RoutePort{
+						TargetPort: intstr.FromString("http2"),
+					},
+				},
+			}},
+		},
+		{
+			name: "invalid LB domain",
+			ingress: ingress(withLBInternalDomain("not.a.private.name"), withRules(
+				rule(withHosts([]string{localDomain, externalDomain}))),
+			),
+			wantErr: ErrNoValidLoadbalancerDomain,
+		},
+		{
+			name: "tls: passthrough termination",
+			ingress: ingress(withTLSTerminationAnnotation("passthrough"), withRules(
+				rule(withHosts([]string{localDomain, externalDomain}))),
+			),
+			want: []*routev1.Route{{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						networking.IngressLabelKey:     uid,
+						serving.RouteLabelKey:          "route1",
+						serving.RouteNamespaceLabelKey: "default",
+					},
+					Annotations: map[string]string{
+						TimeoutAnnotation:        "600s",
+						TLSTerminationAnnotation: "passthrough",
+					},
+					Namespace: lbNamespace,
+					Name:      routeBase + "-1",
+				},
+				Spec: routev1.RouteSpec{
+					Host: externalDomain,
+					To: routev1.RouteTargetReference{
+						Kind: "Service",
+						Name: lbService,
+					},
+					Port: &routev1.RoutePort{
+						TargetPort: intstr.FromString("https"),
+					},
+					TLS: &routev1.TLSConfig{
+						Termination: routev1.TLSTerminationPassthrough,
+					},
+				},
+			}},
+		},
+		{
+			name: "tls: unsupported termination",
+			ingress: ingress(withTLSTerminationAnnotation("edge"), withRules(
+				rule(withHosts([]string{localDomain, externalDomain}))),
+			),
+			wantErr: ErrNotSupportedTLSTermination,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			routes, err := MakeRoutes(test.ingress)
+			if test.want != nil && !cmp.Equal(routes, test.want) {
+				t.Errorf("got = %v, want: %v\ndiff: %s", routes, test.want, cmp.Diff(routes, test.want))
+			}
+			if err != test.wantErr {
+				t.Errorf("got = %v, want: %v", err, test.wantErr)
+			}
+		})
+	}
+}
+
+func ingress(options ...ingressOption) networkingv1alpha1.IngressAccessor {
+	ing := &networkingv1alpha1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				serving.RouteLabelKey:          "route1",
+				serving.RouteNamespaceLabelKey: "default",
+			},
+			Namespace: "default",
+			Name:      "ingress",
+			UID:       uid,
+		},
+		Spec: networkingv1alpha1.IngressSpec{
+			Visibility: networkingv1alpha1.IngressVisibilityExternalIP,
+		},
+		Status: networkingv1alpha1.IngressStatus{
+			LoadBalancer: &networkingv1alpha1.LoadBalancerStatus{
+				Ingress: []networkingv1alpha1.LoadBalancerIngressStatus{{
+					DomainInternal: fmt.Sprintf("%s.%s.svc.cluster.local", lbService, lbNamespace),
+				}},
+			},
+		},
+	}
+
+	for _, opt := range options {
+		opt(ing)
+	}
+
+	return ing
+}
+
+func rule(options ...ruleOption) networkingv1alpha1.IngressRule {
+	rule := networkingv1alpha1.IngressRule{
+		HTTP: &networkingv1alpha1.HTTPIngressRuleValue{
+			Paths: []networkingv1alpha1.HTTPIngressPath{{}},
+		},
+	}
+
+	for _, opt := range options {
+		opt(&rule)
+	}
+
+	return rule
+}
+
+type ingressOption func(networkingv1alpha1.IngressAccessor)
+
+func withRules(rules ...networkingv1alpha1.IngressRule) ingressOption {
+	return func(ing networkingv1alpha1.IngressAccessor) {
+		spec := ing.GetSpec()
+		spec.Rules = rules
+	}
+}
+
+func withDisabledAnnotation(ing networkingv1alpha1.IngressAccessor) {
+	annos := ing.GetAnnotations()
+	if annos == nil {
+		annos = map[string]string{}
+	}
+	annos[DisableRouteAnnotation] = ""
+	ing.SetAnnotations(annos)
+}
+
+func withTLSTerminationAnnotation(value string) ingressOption {
+	return func(ing networkingv1alpha1.IngressAccessor) {
+		annos := ing.GetAnnotations()
+		if annos == nil {
+			annos = map[string]string{}
+		}
+		annos[TLSTerminationAnnotation] = value
+		ing.SetAnnotations(annos)
+	}
+}
+
+func withLocalVisibility(ing networkingv1alpha1.IngressAccessor) {
+	ing.GetSpec().Visibility = networkingv1alpha1.IngressVisibilityClusterLocal
+}
+
+func withLBInternalDomain(domain string) ingressOption {
+	return func(ing networkingv1alpha1.IngressAccessor) {
+		status := ing.GetStatus()
+		status.LoadBalancer.Ingress[0].DomainInternal = domain
+	}
+}
+
+type ruleOption func(*networkingv1alpha1.IngressRule)
+
+func withLocalVisibilityRule(rule *networkingv1alpha1.IngressRule) {
+	rule.Visibility = networkingv1alpha1.IngressVisibilityClusterLocal
+}
+
+func withHosts(hosts []string) ruleOption {
+	return func(rule *networkingv1alpha1.IngressRule) {
+		rule.Hosts = hosts
+	}
+}
+
+func withTimeout(timeout time.Duration) ruleOption {
+	return func(rule *networkingv1alpha1.IngressRule) {
+		rule.HTTP = &networkingv1alpha1.HTTPIngressRuleValue{
+			Paths: []networkingv1alpha1.HTTPIngressPath{{
+				Timeout: &metav1.Duration{Duration: timeout},
+			}},
+		}
+	}
+}

--- a/pkg/reconciler/ingress/resources/route_test.go
+++ b/pkg/reconciler/ingress/resources/route_test.go
@@ -61,7 +61,7 @@ func TestMakeRoute(t *testing.T) {
 						TimeoutAnnotation: "600s",
 					},
 					Namespace: lbNamespace,
-					Name:      routeBase + "-1",
+					Name:      routeName(uid, externalDomain),
 				},
 				Spec: routev1.RouteSpec{
 					Host: externalDomain,
@@ -105,7 +105,7 @@ func TestMakeRoute(t *testing.T) {
 						TimeoutAnnotation: "3600s",
 					},
 					Namespace: lbNamespace,
-					Name:      routeBase + "-1",
+					Name:      routeName(uid, externalDomain),
 				},
 				Spec: routev1.RouteSpec{
 					Host: externalDomain,
@@ -136,7 +136,7 @@ func TestMakeRoute(t *testing.T) {
 						TimeoutAnnotation: "600s",
 					},
 					Namespace: lbNamespace,
-					Name:      routeBase + "-1",
+					Name:      routeName(uid, externalDomain),
 				},
 				Spec: routev1.RouteSpec{
 					Host: externalDomain,
@@ -159,7 +159,7 @@ func TestMakeRoute(t *testing.T) {
 						TimeoutAnnotation: "600s",
 					},
 					Namespace: lbNamespace,
-					Name:      routeBase + "-3",
+					Name:      routeName(uid, externalDomain2),
 				},
 				Spec: routev1.RouteSpec{
 					Host: externalDomain2,
@@ -190,7 +190,7 @@ func TestMakeRoute(t *testing.T) {
 						TimeoutAnnotation: "600s",
 					},
 					Namespace: lbNamespace,
-					Name:      routeBase + "-3",
+					Name:      routeName(uid, externalDomain2),
 				},
 				Spec: routev1.RouteSpec{
 					Host: externalDomain2,
@@ -228,7 +228,7 @@ func TestMakeRoute(t *testing.T) {
 						TLSTerminationAnnotation: "passthrough",
 					},
 					Namespace: lbNamespace,
-					Name:      routeBase + "-1",
+					Name:      routeName(uid, externalDomain),
 				},
 				Spec: routev1.RouteSpec{
 					Host: externalDomain,

--- a/pkg/reconciler/ingress/resources/route_test.go
+++ b/pkg/reconciler/ingress/resources/route_test.go
@@ -256,7 +256,7 @@ func TestMakeRoute(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			routes, err := MakeRoutes(test.ingress)
+			routes, err := MakeRoutes(test.ingress, test.ingress.GetStatus().PublicLoadBalancer.Ingress)
 			if test.want != nil && !cmp.Equal(routes, test.want) {
 				t.Errorf("got = %v, want: %v\ndiff: %s", routes, test.want, cmp.Diff(routes, test.want))
 			}
@@ -282,7 +282,7 @@ func ingress(options ...ingressOption) networkingv1alpha1.IngressAccessor {
 			Visibility: networkingv1alpha1.IngressVisibilityExternalIP,
 		},
 		Status: networkingv1alpha1.IngressStatus{
-			LoadBalancer: &networkingv1alpha1.LoadBalancerStatus{
+			PublicLoadBalancer: &networkingv1alpha1.LoadBalancerStatus{
 				Ingress: []networkingv1alpha1.LoadBalancerIngressStatus{{
 					DomainInternal: fmt.Sprintf("%s.%s.svc.cluster.local", lbService, lbNamespace),
 				}},
@@ -347,7 +347,7 @@ func withLocalVisibility(ing networkingv1alpha1.IngressAccessor) {
 func withLBInternalDomain(domain string) ingressOption {
 	return func(ing networkingv1alpha1.IngressAccessor) {
 		status := ing.GetStatus()
-		status.LoadBalancer.Ingress[0].DomainInternal = domain
+		status.PublicLoadBalancer.Ingress[0].DomainInternal = domain
 	}
 }
 

--- a/vendor/knative.dev/pkg/reconciler/testing/sorter.go
+++ b/vendor/knative.dev/pkg/reconciler/testing/sorter.go
@@ -89,5 +89,5 @@ func (o *ObjectSorter) IndexerForObjectType(obj runtime.Object) cache.Indexer {
 }
 
 func emptyIndexer() cache.Indexer {
-	return cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	return cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }

--- a/vendor/knative.dev/serving/pkg/reconciler/testing/v1alpha1/listers.go
+++ b/vendor/knative.dev/serving/pkg/reconciler/testing/v1alpha1/listers.go
@@ -18,6 +18,8 @@ package v1alpha1
 
 import (
 	certmanagerv1alpha1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+	routev1 "github.com/openshift/api/route/v1"
+	routev1listers "github.com/openshift/client-go/route/listers/route/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2beta1 "k8s.io/api/autoscaling/v2beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -51,6 +53,7 @@ var clientSetSchemes = []func(*runtime.Scheme) error{
 	fakecachingclientset.AddToScheme,
 	certmanagerv1alpha1.AddToScheme,
 	autoscalingv2beta1.AddToScheme,
+	routev1.AddToScheme,
 }
 
 type Listers struct {
@@ -199,4 +202,12 @@ func (l *Listers) GetConfigMapLister() corev1listers.ConfigMapLister {
 // GetNamespaceLister gets lister for Namespace resource.
 func (l *Listers) GetNamespaceLister() corev1listers.NamespaceLister {
 	return corev1listers.NewNamespaceLister(l.IndexerFor(&corev1.Namespace{}))
+}
+
+func (l *Listers) GetOpenshiftRouteLister() routev1listers.RouteLister {
+	return routev1listers.NewRouteLister(l.IndexerFor(&routev1.Route{}))
+}
+
+func (l *Listers) GetOpenshiftObjects() []runtime.Object {
+	return l.sorter.ObjectsForSchemeFunc(routev1.AddToScheme)
 }


### PR DESCRIPTION
As the title says. This ports the route handling capabilities from knative-openshift-ingress to here, with a few enhancements:

- Properly detect cluster-local domains and ignore them.
- Simplified code and minimized duplicated work.
- Stable naming of routes so that changing visibility of rules and hosts does not skrew with the generated routes.

TODO:
- Make all tests pass
- Add lots of tests around route reconcilation